### PR TITLE
Fix grayscale filter

### DIFF
--- a/css/grayscale.svg
+++ b/css/grayscale.svg
@@ -1,8 +1,0 @@
-<svg version="1.1" xmlns="https://www.w3.org/2000/svg">
-<filter id="grayscale">
-<feColorMatrix type="matrix" values="0.3333 0.3333 0.3333 0 0
- 0.3333 0.3333 0.3333 0 0
- 0.3333 0.3333 0.3333 0 0
- 0  0  0  1 0"/>
-</filter>
-</svg>

--- a/css/style.css
+++ b/css/style.css
@@ -125,11 +125,11 @@ footer a {
   height: 48px;
 }
 footer a {
-  filter: grayscale(100%);
-  filter: url(grayscale.svg#grayscale); /* Firefox 4+ */
-  filter: gray; /* IE6-8 */
+  filter: grayscale(1); /* Microsoft Edge and Firefox 35+ */
+  -webkit-filter: grayscale(1); /* Google Chrome, Safari 6+ & Opera 15+ */
+  filter: gray; /* IE6-9 */
 }
-footer a:hover { filter: none; }
+footer a:hover { filter: none; -webkit-filter: none; }
 
 .fb      { background-image: url(img/footer_buttons/fb.png); }
 .tw      { background-image: url(img/footer_buttons/tw.png); }


### PR DESCRIPTION
Fixes the  grayscale effect issue for Chrome. Does not work for IE 10+. The buttons remain colored.

The complexity to get it working for IE10+ seems to be absurd:
https://github.com/karlhorky/gray#how-it-works
https://github.com/Schepp/CSS-Filters-Polyfill#a-word-regarding-ie-10
