### PR TITLE
removed the jenkins and github buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,13 +117,11 @@
               </div>
 
               <div id="development">
-                <a href="https://github.com/MovingBlocks/Terasology">Github Page</a>
-                <a href="https://github.com/MovingBlocks/Terasology/wiki/Contributor-Guide">Contributor Guide</a>
-                <a href="http://forum.terasology.org/forums/contributor-introductions.7/">Contributor Intro</a>
-                <a href="https://github.com/MovingBlocks/Terasology/wiki/Dev-Setup">Development Setup</a>
-                <a href="https://github.com/MovingBlocks/Terasology/wiki/Modding-Guide">Modding Guide</a>
-                <a href="http://jenkins.movingblocks.net/view/Modules/">Modules</a>
-                <a href="#" class="back">Back</a>
+                <a href="https://github.com/MovingBlocks/Terasology">Source Code</a>
+		<a href="https://github.com/MovingBlocks/Terasology/wiki/Contributor-Guide">Contributor Guide</a>
+		<a href="https://github.com/MovingBlocks/Terasology/wiki/Modding-Guide">Module Development</a>
+		<a href="http://jenkins.movingblocks.net/view/Modules/">Modules</a>
+	      <a href="#" class="back">Back</a>
               </div>
           </nav>
 
@@ -133,11 +131,6 @@
             <a href="https://plus.google.com/103835217961917018533" class="gp" rel="publisher"></a>
             <a href="https://www.youtube.com/user/blockmaniaTV" class="yt"></a>
             <a href="https://reddit.com/r/Terasology" class="ri"></a>
-            <a href="https://github.com/MovingBlocks" class="gh"></a>
-
-            <!-- Since this is a splash site, do users need to know what Jenkins is? -->
-            <a href="http://jenkins.terasology.org" class="jenkins"></a>
-
           </footer>
         </div>
 


### PR DESCRIPTION
- the buttons are more for users,Now the buttons are only social media.
  Renamed the Github button to Source Code. Removed Dev set up button: its
  linked twice now in the Contributor Guide, cannot be missed. Renamed
  modding guide to Module Development.
  Removed Contributor Introductions button. 
  Contributor introduction is linked in Contributor Guide. 

Edit: mean removed the jenkins and github icons
