### PR TITLE
Fixed relative URLs on about page

### DIFF
--- a/about.html
+++ b/about.html
@@ -16,15 +16,15 @@ title: "Welcome to The World of Terasology!"
 </div>
 <div class="row">
     <div class="col s6 l3">
-        <img class="img-margin fwidth materialboxed z-depth-3" src="{{ site.github.url }}/img/ss_2.jpg">
+        <img class="img-margin fwidth materialboxed z-depth-3" src="{{ site.baseurl }}/img/ss_2.jpg">
     </div>
     <div class="col s6 l3">
-        <img class="img-margin fwidth materialboxed z-depth-3" src="{{ site.github.url }}/img/ss_3.jpg">
+        <img class="img-margin fwidth materialboxed z-depth-3" src="{{ site.baseurl }}/img/ss_3.jpg">
     </div>
     <div class="col s6 l3">
-        <img class="img-margin fwidth materialboxed z-depth-3" src="{{ site.github.url }}/img/ss_4.jpg">
+        <img class="img-margin fwidth materialboxed z-depth-3" src="{{ site.baseurl }}/img/ss_4.jpg">
     </div>
     <div class="col s6 l3">
-        <img class="img-margin fwidth materialboxed z-depth-3" src="{{ site.github.url }}/img/ss_5.jpg">
+        <img class="img-margin fwidth materialboxed z-depth-3" src="{{ site.baseurl }}/img/ss_5.jpg">
     </div>
 </div>


### PR DESCRIPTION
The images have `site.github.url` instead of `site.baseurl` which messes up with the preview.