### PR TITLE
Fix relative links

### DIFF
--- a/_includes/status.html
+++ b/_includes/status.html
@@ -1,8 +1,8 @@
 <!-- Start ignoring HTMLLintBear -->
 <p>
   <a href="http://jenkins.terasology.org/job/Terasology/"><img src="http://jenkins.terasology.org/job/Terasology/badge/icon" alt="Build Status" /></a>
-  <a href="../../releases/latest"><img src="https://img.shields.io/github/release/MovingBlocks/Terasology.svg" alt="Release" /></a>
-  <a href="../../releases/latest"><img src="https://img.shields.io/github/downloads/MovingBlocks/Terasology/latest/total.svg" alt="Downloads" title="Downloads" /></a>
+  <a href="https://github.com/MovingBlocks/Terasology/releases/latest"><img src="https://img.shields.io/github/release/MovingBlocks/Terasology.svg" alt="Release" /></a>
+  <a href="https://github.com/MovingBlocks/Terasology/releases/latest"><img src="https://img.shields.io/github/downloads/MovingBlocks/Terasology/latest/total.svg" alt="Downloads" title="Downloads" /></a>
   <a href="https://www.bountysource.com/teams/MovingBlocks"><img src="https://img.shields.io/bountysource/team/MovingBlocks/activity.svg" alt="Bounties" /></a>
   <a href="http://www.apache.org/licenses/LICENSE-2.0"><img src="https://img.shields.io/badge/license(code)-Apache%202.0-blue.svg
     " /></a>


### PR DESCRIPTION
Got reported on Discord earlier. Some of the About page stuff is copy pasta from Terasology's readme, yet relative links don't work so well on a different site!

I was wondering if we were maybe dynamically including stuff instead, which would probably be better, but right now we're not so this seems a straight forward fix.