### PR TITLE
Add Patreon link to navigation bar

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -23,6 +23,7 @@
           <li><a aria-label="Gallery" href="{{ "/gallery.html" | prepend: site.baseurl }}">Gallery</a></li>
           <li><a aria-label="Forum" href="http://forum.terasology.org">Forum</a></li>
           <li class="green darken-2"><a aria-label="Download Terasology" class="dl-link" href="https://github.com/MovingBlocks/TerasologyLauncher/releases/latest"><i class="material-icons left">cloud_download</i>Get The Game!</a></li>
+          <li class="red lighten-1"> <a href="https://www.patreon.com/Terasology"><img style="height:68%;;"class="img-margin   z-depth-3" src="{{ site.baseurl}}/img/patron.png" alt="Patreon to donate money"</a></li>
         </ul>
     </nav>
   </div>
@@ -32,6 +33,7 @@
     <li><a aria-label="Gallery"  href="{{ "/gallery.html" | prepend: site.baseurl }}">Gallery</a></li>
     <li><a aria-label="Forum"  href="http://forum.terasology.org">Forum</a></li>
     <li class="grey lighten-2"><a aria-label="Download Terasology" class="dl-link" href="https://github.com/MovingBlocks/TerasologyLauncher/releases/latest"><i class="material-icons right">cloud_download</i>Download</a></li>
+    <li class="red lighten-1"> <a href="https://www.patreon.com/Terasology"><img style="height:68%;;"class="img-margin   z-depth-3" src="{{ site.baseurl}}/img/patron.png" alt="Patreon to donate money"</a></li>
   </ul>
 </header>
 <!-- Stop ignoring HTMLLintBear -->


### PR DESCRIPTION
Issue Id: #114
Problem: The navigation menu did not have a patron link.
How-to-check: Looking up on the navigation bar in desktop view also in mobile view.