### PR TITLE
feat(download): use launcher v4.0.0-rc.4

### DIFF
--- a/js/OSdetect.js
+++ b/js/OSdetect.js
@@ -19,7 +19,7 @@ if (navigator.appVersion.indexOf("Linux") != -1) {
     selectElement("Linux (64-Bit)");
 }
 var xmlhttp = new XMLHttpRequest();
-xmlhttp.open("GET", "https://api.github.com/repos/MovingBlocks/TerasologyLauncher/releases/tags/v4.0.0-rc.3", true);
+xmlhttp.open("GET", "https://api.github.com/repos/MovingBlocks/TerasologyLauncher/releases/tags/v4.0.0-rc.4", true);
 xmlhttp.send();
 
 function downloadPackage() {

--- a/js/OSdetect.js
+++ b/js/OSdetect.js
@@ -19,7 +19,7 @@ if (navigator.appVersion.indexOf("Linux") != -1) {
     selectElement("Linux (64-Bit)");
 }
 var xmlhttp = new XMLHttpRequest();
-xmlhttp.open("GET", "https://api.github.com/repos/MovingBlocks/TerasologyLauncher/releases/tags/v4.0.0-rc.2", true);
+xmlhttp.open("GET", "https://api.github.com/repos/MovingBlocks/TerasologyLauncher/releases/tags/v4.0.0-rc.3", true);
 xmlhttp.send();
 
 function downloadPackage() {


### PR DESCRIPTION
v4.0.0-rc2 still uses the old sources.json, this is why we need to switch to a newer release candidate