### PR TITLE
chore: clean-up About page a bit

### DIFF
--- a/about.html
+++ b/about.html
@@ -7,16 +7,14 @@ title: "Welcome to The World of Terasology!"
   <p>
     Terasology is a super extensible open source voxel-based
     game. Born from a Minecraft-inspired tech demo, it is gradually becoming
-    a stable platform for all sorts of gameplay settings in a voxel world.
+    a platform for all sorts of gameplay settings in a voxel world.
   </p>
   <p>
-    From the ground up, Terasology was built to be a super hackable and
-    modular game. We host a large number of modules under the
-    <a aria-label="Terasology on GitHub" href="http://github.com/Terasology">Terasology</a> organization and
-    many more which are maintained by individual enthusiasts. We welcome new
-    ideas, both crazy and well thought-out for modules and game extensions
-    from anyone and everyone, so feel free to talk to us on our
-    <a aria-label="Terasology Discord Link" href="https://discordapp.com">Discord</a> or IRC (#terasology on Freenode).
+    From the ground up, <a aria-label="Terasology on GitHub" href="https://github.com/MovingBlocks/Terasology">Terasology</a> was built to be a modular and extensible game. 
+    We host a large number of <a aria-label="Terasology modules on GitHub" href="http://github.com/Terasology">modules</a> on Github, and publish
+    a playable bundle as "Omega" distribution for everyone to try out. 
+    We welcome new ideas, both crazy and well thought-out for modules and game extensions from anyone and everyone, so feel free to talk to us on our
+    <a aria-label="Terasology Discord Link" href="https://discordapp.com">Discord</a>.
   </p>
   <p>
     The creators and maintainers are a diverse mix of software developers,
@@ -26,14 +24,14 @@ title: "Welcome to The World of Terasology!"
     newcomers.
   </p>
   <p>
-    Terasology is fully open source and is licensed under the Apache 2.0
-    license for code and under CC BY 4.0 for artwork (see credits for some
-    minor exceptions).
+    Terasology is fully open source and is licensed under the <a href="http://www.apache.org/licenses/LICENSE-2.0.html">Apache 2.0</a>
+    license for code and under <a href="http://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a> for artwork.
   </p>
   <p>
+    We encourage contributions from anybody and try to keep a warm and friendly community and maintain a 
+    <a aria-label="Terasology Code of Conduct" href="https://github.com/MovingBlocks/Terasology/blob/develop/docs/CODE_OF_CONDUCT.md">code of conduct</a>.
     If you have any questions or if you just want to chat use this invite link for our
-    <a aria-label="Terasology Discord Link" href="https://discord.gg/Terasology">Discord</a>, or check out our IRC channel #terasology on Freenode.
-    And don't worry about missing something by joining only one of those, as we have everything bridged. :)
+    <a aria-label="Terasology Discord Link" href="https://discord.gg/Terasology">Discord</a>.
   </p>
 </div>
 <div class="row">


### PR DESCRIPTION
Clean up the information on the About page a bit (e.g., remove references to IRC).

This is not a complete overhaul, but should be enough to bring this page back up to date. Ideally, the website should take this information from somewhere else, probably the main project's README? This is something that we can potentially do on the new Module Site with Gatsby's GraphQL queries...

Closes #76
